### PR TITLE
fix for images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,3 +55,5 @@ cous-brochette-poulet: '3,40€'
 cous-boulettes: '3,40€'
 cous-brochette-agneau: '3,60€'
 cous-gigot: '4,80€'
+
+baseurl: 'excellence-kebab'


### PR DESCRIPTION
Tu devras supprimer ça si un nom de domaine pointe dessus
Avec baseurl il va chercher les images dans  /excellence-kebab/assets/ alors que sans baseurl il va les chercher dans /assets/